### PR TITLE
testing Nexus IQ for Github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .DS_Store
 /target/
 *.jar
+metadata.json

--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ the default messages defined in package.properties are in English. If the defaul
 locale for your server is different, then rename package.properties to package_en.properties
 and create a new package.properties with proper values for your default locale.
 ```
+testing [Nexus IQ for GitHub](https://help.sonatype.com/integrations/nexus-iq-for-github)


### PR DESCRIPTION
followed instructions at https://help.sonatype.com/integrations/nexus-iq-for-github

only issue is that `baseUrl` has to be configured in `config.yml`, or you'll find an exception in `clm-server.log`